### PR TITLE
Allow build_boost.bat to take msvc argument if present.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ or source code.
 1. Run `git submodule update --init --recursive` so that all dependencies like Jannson, Google Test
    and etc. get downloaded and linked to the correct revisions.
 2. Run the JContainer's `tools\build_boost.bat` file. It should manage to download, unpack,
-   bootstrap and build the neccessary libraries from Boost (version 1.67 currently).
+   bootstrap and build the neccessary libraries from Boost (version 1.67 currently). If you encounter
+   boost linking errors later on, you can attempt to specify the msvc version when running the batch
+   file, e.g. `tools\build_boost.bat vc141`.
 3. Run also the `tools\merge_skse.bat` file. It should extract the stripped down and bundled SKSE64
    and SKSE VR distributions into the local source tree.
 4. Open the `JContainers.sln` file with Visual Studio and Rebuild the whole solution. It will take

--- a/tools/build_boost.bat
+++ b/tools/build_boost.bat
@@ -39,7 +39,7 @@ pushd "%BOOST_ROOT%"
 
 if not exist b2.exe ( 
     echo b2 not found, bootstrapping Boost...
-    call bootstrap.bat
+    call bootstrap.bat %1
     if errorlevel 1 (
         echo Unable to bootstrap, exiting...
         popd


### PR DESCRIPTION
The commit is functionally identical to the following code:

```bat
	if [%1]==[] (
		call bootstrap.bat
	) else (
		call bootstrap.bat %1
	)
````

If no argument is provided, bootstrap.bat will default to the global version.
This PR should allow JContainers to more easily be built in Github CI Workflows.

Closes #72 