### PR TITLE
API versioning + insertItem/ToJSONString/Stoul

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 image: Visual Studio 2019
-version: '4.2.13.1'
+version: '4.2.13.1.{build}'
 platform: x64
 branches:
     only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 image: Visual Studio 2019
-version: '4.2.13.{build}'
+version: '4.2.13.1'
 platform: x64
 branches:
     only:

--- a/src/JContainers/src/api_3/tes_map.h
+++ b/src/JContainers/src/api_3/tes_map.h
@@ -51,6 +51,28 @@ namespace tes_api_3 {
         REGISTERF(setItem<object_base*>, "setObj", "* key container", "");
         REGISTERF(setItem<form_ref>, "setForm", "* key value", "");
 
+        template<class T>
+        static T insertItem (tes_context& ctx, ref obj, key_cref key, T val)
+        {
+            JC_LOG_API ("%p, ..., ...", (void*) obj);
+            if (obj && map_key_checker::check (key))
+            {
+                object_lock g (obj);
+                if (item* i = obj->u_get (key))
+                {
+                    return i->readAs<T> ();
+                }
+                obj->u_get_or_create (key) = val;
+                return val;
+            }
+            return default_value<T> ();
+        }
+        REGISTERF (insertItem<SInt32>, "insertInt", "* key value", "Inserts @key: @value pair. Does nothing if the @key already exists");
+        REGISTERF (insertItem<Float32>, "insertFlt", "* key value", "");
+        REGISTERF (insertItem<skse::string_ref>, "insertStr", "* key value", "");
+        REGISTERF (insertItem<object_base*>, "insertObj", "* key container", "");
+        REGISTERF (insertItem<form_ref>, "insertForm", "* key value", "");
+
         static bool hasKey(tes_context& ctx, ref obj, key_cref key) {
             JC_LOG_API ("%p, ...", (void*) obj);
             return valueType(ctx, obj, key) != 0;

--- a/src/JContainers/src/api_3/tes_object.h
+++ b/src/JContainers/src/api_3/tes_object.h
@@ -315,6 +315,28 @@ JValue.cleanPool(\"uniquePoolName\")"
         }
         REGISTERF(writeToFile, "writeToFile", "* filePath", "Writes the object into JSON file");
 
+        static skse::string_ref toJsonString (tes_context& ctx, object_base* obj)
+        {
+            JC_LOG_API ("0x%p", (void*) obj);
+
+            skse::string_ref result;
+            if (obj)
+            {
+                auto json = json_serializer::create_json_value (*obj);
+                if (json)
+                {
+                    char* str = json_dumps (json.get (), JSON_INDENT (2));
+                    if (str)
+                    {
+                        result = skse::string_ref (str);
+                        free (str);
+                    }
+                }
+            }
+            return result;
+        }
+        REGISTERF (toJsonString, "toJsonString", "*", "Serializes the object into JSON string and returns it");
+
         static SInt32 solvedValueType(tes_context& ctx, object_base* obj, const char *path)
         {
             JC_LOG_API ("0x%p, \"%s\"", (void*) obj, path ? path : "<nullptr>");

--- a/src/JContainers/src/jcontainers_constants.h
+++ b/src/JContainers/src/jcontainers_constants.h
@@ -7,12 +7,14 @@ namespace collections {
 #   define JC_API_VERSION           4
 #   define JC_FEATURE_VERSION       2
 #   define JC_PATCH_VERSION         13
+#   define JC_REVISION_VERSION      1
 
-#   define JC_FILE_VERSION          JC_API_VERSION, JC_FEATURE_VERSION, JC_PATCH_VERSION, 0
+#   define JC_FILE_VERSION          JC_API_VERSION, JC_FEATURE_VERSION, JC_PATCH_VERSION, JC_REVISION_VERSION
 
 #   define JC_VERSION_STR           STR(JC_API_VERSION)           \
                                     "." STR(JC_FEATURE_VERSION)   \
-                                    "." STR(JC_PATCH_VERSION)
+                                    "." STR(JC_PATCH_VERSION)     \
+                                    "." STR(JC_REVISION_VERSION)
 
 #   define JC_DATA_FILES            "JCData/"
 
@@ -47,6 +49,7 @@ namespace collections {
         api_version = JC_API_VERSION,
         feature_version = JC_FEATURE_VERSION,
         patch_version = JC_PATCH_VERSION,
+        revision_version = JC_REVISION_VERSION,
     };
 
 }


### PR DESCRIPTION
* Added new API functions: `minorVersion`, `patchVersion`, `versionInt`, `versionString`, and `versionAtLeast` for more granular and user-friendly version checks.
* Added new `insertItem` API functions (`insertInt`, `insertFlt`, `insertStr`, `insertObj`, `insertForm`) for inserting key-value pairs only if the key does not already exist.
* Added a `toJsonString` function to serialize objects directly into a JSON string.
* Added a `stoul` function to convert a string to an unsigned integer with base support
